### PR TITLE
Update SimpleScriptRunner to use MySqlConnector instead of MySql.Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SimpleScriptRunner.exe <serverName> <databaseName> <path to folder containing sq
 ```
 or for SQL Authentication
 ```
-SimpleScriptRunner.exe <serverName> <username> <password> <databaseName> <path to folder containing sql scripts> [options]
+SimpleScriptRunner.exe <serverName> <databaseName> <username> <password> <path to folder containing sql scripts> [options]
 ```
 
 the sql scripts should start with the script version number and then a space, and be grouped into numbered Release folders.

--- a/SampleDb/SampleDb.csproj
+++ b/SampleDb/SampleDb.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SimpleScriptProgram/SimpleScriptProgram.csproj
+++ b/SimpleScriptProgram/SimpleScriptProgram.csproj
@@ -2,10 +2,14 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+        <TargetFrameworks>net7.0;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\SimpleScriptRunnerBto\SimpleScriptRunnerBto.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     </ItemGroup>
 </Project>

--- a/SimpleScriptRunnerBto/MySql/SqlDatabase.cs
+++ b/SimpleScriptRunnerBto/MySql/SqlDatabase.cs
@@ -2,7 +2,8 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Text;
-using MySql.Data.MySqlClient;
+using Dapper;
+using MySqlConnector;
 
 namespace SimpleScriptRunnerBto.MySql
 {
@@ -66,20 +67,21 @@ VALUES (@Major,@Minor,@Patch,@Modified,@MachineName,@Description)
             if (connectionString == null)
             {
                 StringBuilder builder = new StringBuilder();
-                builder.Append("Server=").Append(options.ServerName).Append(";");
-                builder.Append("Port=").Append("3306").Append(";");
-                builder.Append("Database=").Append(options.DatabaseName).Append(";");
+                builder.Append($"Server={options.ServerName};");
+                builder.Append("Port=3306;");
+                builder.Append($"Database={options.DatabaseName};");
                 if (options.UserName != null && options.Password != null)
                 {
-                    builder.Append("Uid=").Append(options.UserName).Append(";");
-                    builder.Append("Pwd=").Append(options.Password).Append(";");
+                    builder.Append($"Uid={options.UserName};");
+                    builder.Append($"Pwd={options.Password};");
                 }
-                builder.Append("pooling=").Append("false").Append(";");
+                builder.Append("Pooling=false;");
+                builder.Append("AllowUserVariables=true;");
                 if (options.SslMode != null)
-                    builder.Append("SslMode=").Append(options.SslMode).Append(";");
+                    builder.Append($"SslMode={options.SslMode};");
 
-                int timeOut = 15 * 60; 
-                builder.Append("defaultcommandtimeout=").Append(timeOut).Append(";");
+                int timeOut = 15 * 60; // 15 minutes
+                builder.Append($"DefaultCommandTimeout={timeOut};");
 
                 connectionString = builder.ToString();
             }
@@ -231,8 +233,11 @@ order by Patch
 
         public void apply(string content)
         {
-            MySqlScript script = new MySqlScript(connection, content);
-            script.Execute();
+            if (string.IsNullOrWhiteSpace(content)) return;
+            
+            connection.Execute(content);
+            // MySqlScript script = new MySqlScript(connection, content);
+            // script.Execute();
         }
 
         public void updateVersion(ScriptVersion version)

--- a/SimpleScriptRunnerBto/SimpleScriptRunnerBto.csproj
+++ b/SimpleScriptRunnerBto/SimpleScriptRunnerBto.csproj
@@ -10,11 +10,12 @@
         <PackageLicenseUrl>https://github.com/ericraider33/SimpleScriptRunner/blob/master/LICENSE.md</PackageLicenseUrl>
         <PackageTags>MySQL Database Migrations Scripts Version DevOps CommandLine</PackageTags>
         <PackageReleaseNotes>Modified directory scan to sort results to be consistent between win/Linux</PackageReleaseNotes>
-        <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
+        <TargetFramework>netstandard2.1</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MySql.Data" Version="8.2.0" />
+      <PackageReference Include="Dapper" Version="2.1.24" />
+      <PackageReference Include="MySqlConnector" Version="2.3.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull requests makes the following changes:

- SimpleScriptRunnerBto is updated to use [MySqlConnector](https://mysqlconnector.net/) instead of [MySql.Data (Connector/Net)](https://dev.mysql.com/doc/connector-net/en/)
- SimpleScriptRunnerBto will target .NET Standard 2.1
- SimpleScriptRunnerProgram and SampleDb projects will target .NET 6, 7, and 8