### PR TITLE
Re-target for .NET 6, 7, and 8

### DIFF
--- a/SampleDb/Program.cs
+++ b/SampleDb/Program.cs
@@ -1,19 +1,11 @@
 ﻿using SimpleScriptRunnerBto;
 
-namespace SampleDb;
+Options options = new Options();
+options.UseTransactions = true;
+options.ServerName = "localhost";
+options.DatabaseName = "simple_script_runner_sample";
+options.UserName = "simplescriptadmin";
+options.Password = "abc123";
+options.Path = "sample";
 
-class Program
-{
-    static void Main(string[] args)
-    {
-        Options options = new Options();
-        options.UseTransactions = true;
-        options.ServerName = "localhost";
-        options.DatabaseName = "simple_script_runner_sample";
-        options.UserName = "simplescriptadmin";
-        options.Password = "abc123";
-        options.Path = "sample";
-
-        TopProgram.simpleScriptRunnerProgramMain(options);
-    }
-}
+TopProgram.simpleScriptRunnerProgramMain(options);

--- a/SampleDb/Program.cs
+++ b/SampleDb/Program.cs
@@ -1,20 +1,19 @@
 ﻿using SimpleScriptRunnerBto;
 
-namespace SampleDb
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            Options options = new Options();
-            options.UseTransactions = true;
-            options.ServerName = "localhost";
-            options.DatabaseName = "simple_script_runner_sample";
-            options.UserName = "simplescriptadmin";
-            options.Password = "abc123";
-            options.Path = "sample";
+namespace SampleDb;
 
-            TopProgram.simpleScriptRunnerProgramMain(options);
-        }
+class Program
+{
+    static void Main(string[] args)
+    {
+        Options options = new Options();
+        options.UseTransactions = true;
+        options.ServerName = "localhost";
+        options.DatabaseName = "simple_script_runner_sample";
+        options.UserName = "simplescriptadmin";
+        options.Password = "abc123";
+        options.Path = "sample";
+
+        TopProgram.simpleScriptRunnerProgramMain(options);
     }
 }

--- a/SimpleScriptProgram/Program.cs
+++ b/SimpleScriptProgram/Program.cs
@@ -2,22 +2,21 @@ using System;
 using System.Configuration;
 using SimpleScriptRunnerBto;
 
-namespace SimpleScriptProgram
+namespace SimpleScriptProgram;
+
+public class Program
 {
-    public class Program
+    public static int Main(string[] args)
     {
-        public static int Main(string[] args)
+        try
         {
-            try
-            {
-                return TopProgram.main(ConfigurationManager.AppSettings, args);
-            }
-            catch (Exception error)
-            {
-                Console.Error.WriteLine("Error: " + error.Message);
-                Console.Error.WriteLine(error.StackTrace);
-                return 1;
-            }
+            return TopProgram.main(ConfigurationManager.AppSettings, args);
+        }
+        catch (Exception error)
+        {
+            Console.Error.WriteLine("Error: " + error.Message);
+            Console.Error.WriteLine(error.StackTrace);
+            return 1;
         }
     }
 }

--- a/SimpleScriptProgram/Program.cs
+++ b/SimpleScriptProgram/Program.cs
@@ -2,21 +2,13 @@ using System;
 using System.Configuration;
 using SimpleScriptRunnerBto;
 
-namespace SimpleScriptProgram;
-
-public class Program
+try
 {
-    public static int Main(string[] args)
-    {
-        try
-        {
-            return TopProgram.main(ConfigurationManager.AppSettings, args);
-        }
-        catch (Exception error)
-        {
-            Console.Error.WriteLine("Error: " + error.Message);
-            Console.Error.WriteLine(error.StackTrace);
-            return 1;
-        }
-    }
+    return TopProgram.main(ConfigurationManager.AppSettings, args);
+}
+catch (Exception error)
+{
+    Console.Error.WriteLine("Error: " + error.Message);
+    Console.Error.WriteLine(error.StackTrace);
+    return 1;
 }

--- a/SimpleScriptRunnerBto/FolderContainingNumberedSqlScripts.cs
+++ b/SimpleScriptRunnerBto/FolderContainingNumberedSqlScripts.cs
@@ -4,25 +4,25 @@ using System.IO;
 using System.Linq;
 using SimpleScriptRunnerBto.Util;
 
-namespace SimpleScriptRunnerBto
-{
-    internal class FolderContainingNumberedSqlScripts : IScriptSource<ITextScriptTarget>
-    {
-        private readonly string path;
-        private readonly string searchPattern;
+namespace SimpleScriptRunnerBto;
 
-        public FolderContainingNumberedSqlScripts(string path, string searchPattern)
-        {
+internal class FolderContainingNumberedSqlScripts : IScriptSource<ITextScriptTarget>
+{
+    private readonly string path;
+    private readonly string searchPattern;
+
+    public FolderContainingNumberedSqlScripts(string path, string searchPattern)
+    {
             this.path = path;
             this.searchPattern = searchPattern;
         }
 
-        #region IScriptSource<ITextScriptTarget> Members
+    #region IScriptSource<ITextScriptTarget> Members
 
-        public IEnumerable<IScript<ITextScriptTarget>> Scripts
+    public IEnumerable<IScript<ITextScriptTarget>> Scripts
+    {
+        get
         {
-            get
-            {
                 DirectoryInfo directory = new DirectoryInfo(path);
 
                 // Parses release number
@@ -43,10 +43,10 @@ namespace SimpleScriptRunnerBto
 
                 return result;
             }
-        }
+    }
 
-        private NumberedTextScript buildScript(int major, int minor, FileInfo file, int counter)
-        {
+    private NumberedTextScript buildScript(int major, int minor, FileInfo file, int counter)
+    {
             Tuple<String, String> pair = file.Name.splitAt(" ");
             string scriptNumberText = pair.Item1.Trim();
             string description = pair.Item2.Trim();
@@ -69,6 +69,5 @@ namespace SimpleScriptRunnerBto
             return result;
         }
 
-        #endregion
-    }
+    #endregion
 }

--- a/SimpleScriptRunnerBto/IScript.cs
+++ b/SimpleScriptRunnerBto/IScript.cs
@@ -1,8 +1,7 @@
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public interface IScript<T> where T : IScriptTarget
 {
-	public interface IScript<T> where T : IScriptTarget
-	{
-		ScriptVersion Version { get; }
-        void apply(T scriptTarget, Options options);
-    }
+	ScriptVersion Version { get; }
+	void apply(T scriptTarget, Options options);
 }

--- a/SimpleScriptRunnerBto/IScriptSource.cs
+++ b/SimpleScriptRunnerBto/IScriptSource.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public interface IScriptSource<T> where T : IScriptTarget
 {
-	public interface IScriptSource<T> where T : IScriptTarget
-	{
-		IEnumerable<IScript<T>> Scripts { get; }
-	}
+	IEnumerable<IScript<T>> Scripts { get; }
 }

--- a/SimpleScriptRunnerBto/IScriptTarget.cs
+++ b/SimpleScriptRunnerBto/IScriptTarget.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public interface IScriptTarget
 {
-	public interface IScriptTarget
-	{
-		ScriptVersion CurrentVersion { get; }
-		List<ScriptVersion> getPatches(int major, int minor);
-	}
+	ScriptVersion CurrentVersion { get; }
+	List<ScriptVersion> getPatches(int major, int minor);
 }

--- a/SimpleScriptRunnerBto/ITextScriptTarget.cs
+++ b/SimpleScriptRunnerBto/ITextScriptTarget.cs
@@ -1,8 +1,7 @@
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public interface ITextScriptTarget : IScriptTarget
 {
-	public interface ITextScriptTarget : IScriptTarget
-	{
-        void apply(string content);
-        void updateVersion(ScriptVersion version);
-    }
+	void apply(string content);
+	void updateVersion(ScriptVersion version);
 }

--- a/SimpleScriptRunnerBto/NumberedTextScript.cs
+++ b/SimpleScriptRunnerBto/NumberedTextScript.cs
@@ -2,22 +2,22 @@ using System;
 using System.IO;
 using System.Transactions;
 
-namespace SimpleScriptRunnerBto
-{
-    public class NumberedTextScript : IScript<ITextScriptTarget>, IComparable
-    {
-        private readonly string path;
+namespace SimpleScriptRunnerBto;
 
-        public NumberedTextScript(FileInfo fileInfo, int major, int minor, long scriptNumber, string description)
-        {
+public class NumberedTextScript : IScript<ITextScriptTarget>, IComparable
+{
+    private readonly string path;
+
+    public NumberedTextScript(FileInfo fileInfo, int major, int minor, long scriptNumber, string description)
+    {
             path = fileInfo.FullName;
             Version = new ScriptVersion(major, minor, scriptNumber, fileInfo.LastWriteTime, Environment.MachineName, description);
         }
 
-        public ScriptVersion Version { get; private set; }
+    public ScriptVersion Version { get; private set; }
 
-        public void apply(ITextScriptTarget scriptTarget, Options options)
-        {
+    public void apply(ITextScriptTarget scriptTarget, Options options)
+    {
             var prevVersion = scriptTarget.CurrentVersion;
             var sql = File.ReadAllText(path);
             TransactionScope ts = null;
@@ -52,15 +52,14 @@ namespace SimpleScriptRunnerBto
             }
         }
 
-        public override string ToString()
-        {
+    public override string ToString()
+    {
             return path;
         }
 
-        public int CompareTo(object obj)
-        {
+    public int CompareTo(object obj)
+    {
             NumberedTextScript other = (NumberedTextScript)obj;
             return Version.CompareTo(other.Version);
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Options.cs
+++ b/SimpleScriptRunnerBto/Options.cs
@@ -4,33 +4,33 @@ using System.Linq;
 using SimpleScriptRunnerBto.Util;
 using System.Transactions;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public class Options
 {
-    public class Options
-    {
-        public bool RequireRollback { get; set; }
-        public bool UseTransactions { get; set; }
-        public long? MaxPatch { get; set; }
-        public bool SkipVersion { get; set; }
-        public bool SqlFile { get; set; }
-        public TimeSpan TransactionTimeout { get; set; }
-        public String SslMode { get; set; }
+    public bool RequireRollback { get; set; }
+    public bool UseTransactions { get; set; }
+    public long? MaxPatch { get; set; }
+    public bool SkipVersion { get; set; }
+    public bool SqlFile { get; set; }
+    public TimeSpan TransactionTimeout { get; set; }
+    public String SslMode { get; set; }
 
-        public String ServerName { get; set; }
-        public String DatabaseName { get; set; }
-        public String UserName { get; set; }
-        public String Password { get; set; }
+    public String ServerName { get; set; }
+    public String DatabaseName { get; set; }
+    public String UserName { get; set; }
+    public String Password { get; set; }
         
-        public String Path { get; set; }
-        public String[] Params { get; set; }
+    public String Path { get; set; }
+    public String[] Params { get; set; }
 
-        public Options()
-        {
+    public Options()
+    {
             TransactionTimeout = TransactionManager.DefaultTimeout;
         }
 
-        public void parseArgs(String[] argArray)
-        {
+    public void parseArgs(String[] argArray)
+    {
             argArray = argArray.ToArray();        // Copies so that caller is unchanged
             Dictionary<String, String> switches = ArgsUtil.parseDictionary(ref argArray);
 
@@ -56,8 +56,7 @@ namespace SimpleScriptRunnerBto
             SqlFile = switches.hasAny("-sqlfile", "--sqlfile", "-sf");
             SslMode = switches.value("--sslmode", "-sm");
 
-            double? timeoutValue = switches.valueDouble("-trantimeout", "--trantimeout", "-to");            // specified in minutes, fractional is fine 
-            if (timeoutValue.HasValue)
+            double? timeoutValue = switches.valueDouble("-trantimeout", "--trantimeout", "-to");            // specified in minutes, fractional is fine      if (timeoutValue.HasValue)
             {
                 // Validates that timeout against maximum value
                 TimeSpan timeout = TimeSpan.FromMinutes(timeoutValue.Value);            
@@ -76,11 +75,10 @@ namespace SimpleScriptRunnerBto
             }
         }
 
-        public static Options build(String[] argArray)
-        {
+    public static Options build(String[] argArray)
+    {
             Options options = new Options();
             options.parseArgs(argArray);
             return options;
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Program.cs
+++ b/SimpleScriptRunnerBto/Program.cs
@@ -6,79 +6,78 @@ using System.Reflection;
 using SimpleScriptRunnerBto.MySql;
 using SimpleScriptRunnerBto.Util;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public class Program
 {
-    public class Program
+    public enum Category
     {
-        public enum Category
+        error,
+        warning
+    }
+
+    public static int originalMain(string[] argArray)
+    {
+        try
         {
-            error,
-            warning
+            Options options = Options.build(argArray);
+            executeRelease(options);
+            return 0;
         }
-
-        public static int originalMain(string[] argArray)
+        catch (Exception ex)
         {
-            try
-            {
-                Options options = Options.build(argArray);
-                executeRelease(options);
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                WriteMessage(Assembly.GetExecutingAssembly().FullName, string.Empty, Category.error, "1", ex.ToString());
-                return 1;
-            }
+            WriteMessage(Assembly.GetExecutingAssembly().FullName, string.Empty, Category.error, "1", ex.ToString());
+            return 1;
         }
+    }
 
-        public static void executeRelease(Options options)
-        {
-            SqlDatabase scriptTarget = new SqlDatabase(options);
+    public static void executeRelease(Options options)
+    {
+        SqlDatabase scriptTarget = new SqlDatabase(options);
 
-            String releasePath = Path.Combine(options.Path, ReleaseDir.RELEASE);
-            String[] matchingReleases = Directory.GetDirectories(options.Path, "*");
-            List<ReleaseDir> releases = matchingReleases
-                .Where(x => x.startsWithIgnoreCase(releasePath))            // case insensitive directory scan
-                .Select(ReleaseDir.fromPath)
-                .Where(x => x != null)
-                .OrderBy(x => x.ReleaseVersion)
-                .ToList();
+        String releasePath = Path.Combine(options.Path, ReleaseDir.RELEASE);
+        String[] matchingReleases = Directory.GetDirectories(options.Path, "*");
+        List<ReleaseDir> releases = matchingReleases
+            .Where(x => x.startsWithIgnoreCase(releasePath))            // case insensitive directory scan
+            .Select(ReleaseDir.fromPath)
+            .Where(x => x != null)
+            .OrderBy(x => x.ReleaseVersion)
+            .ToList();
             
-            ScriptVersion currentVersion = scriptTarget.CurrentVersion;                                                     // only reads version once and relies on scripts executing in proper order
-            foreach (ReleaseDir releaseDirectory in releases)
-            {
-                IScriptSource<ITextScriptTarget> scriptSource = new FolderContainingNumberedSqlScripts(releaseDirectory.Path, "*.sql");
-                Updater updater = new Updater(scriptSource, scriptTarget, options);
-                updater.applyScripts(currentVersion);
-            }
+        ScriptVersion currentVersion = scriptTarget.CurrentVersion;                                                     // only reads version once and relies on scripts executing in proper order
+        foreach (ReleaseDir releaseDirectory in releases)
+        {
+            IScriptSource<ITextScriptTarget> scriptSource = new FolderContainingNumberedSqlScripts(releaseDirectory.Path, "*.sql");
+            Updater updater = new Updater(scriptSource, scriptTarget, options);
+            updater.applyScripts(currentVersion);
         }
+    }
         
 
-        public static int executeSqlFile(Options options)
+    public static int executeSqlFile(Options options)
+    {
+        try
         {
-            try
-            {
             
-                SqlDatabase scriptTarget = new SqlDatabase(options);
+            SqlDatabase scriptTarget = new SqlDatabase(options);
 
-                options.SkipVersion = true;         // turns off setting patch version since file is free form sql
+            options.SkipVersion = true;         // turns off setting patch version since file is free form sql
 
-                FileInfo file = new FileInfo(options.Path);
-                IScript<ITextScriptTarget> script = new NumberedTextScript(file, 0, 0, 0, "");
-                script.apply(scriptTarget, options);
+            FileInfo file = new FileInfo(options.Path);
+            IScript<ITextScriptTarget> script = new NumberedTextScript(file, 0, 0, 0, "");
+            script.apply(scriptTarget, options);
 
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                WriteMessage(Assembly.GetExecutingAssembly().FullName, string.Empty, Category.error, "1", ex.ToString());
-                return 1;
-            }
+            return 0;
         }
-
-        private static void WriteMessage(string origin, string subcategory, Category category, string code, string text)
+        catch (Exception ex)
         {
-            Console.WriteLine("{0} : {1} {2} {3} : {4}", origin, subcategory, category, code, text);
+            WriteMessage(Assembly.GetExecutingAssembly().FullName, string.Empty, Category.error, "1", ex.ToString());
+            return 1;
         }
+    }
+
+    private static void WriteMessage(string origin, string subcategory, Category category, string code, string text)
+    {
+        Console.WriteLine("{0} : {1} {2} {3} : {4}", origin, subcategory, category, code, text);
     }
 }

--- a/SimpleScriptRunnerBto/ReleaseDir.cs
+++ b/SimpleScriptRunnerBto/ReleaseDir.cs
@@ -1,17 +1,17 @@
 using System;
 using SimpleScriptRunnerBto.Util;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public class ReleaseDir
 {
-    public class ReleaseDir
+    public const string RELEASE = "Release";
+
+    public string Path { get; set; }
+    public decimal ReleaseVersion { get; set; }
+
+    public static ReleaseDir fromPath(string path)
     {
-        public const string RELEASE = "Release";
-
-        public string Path { get; set; }
-        public decimal ReleaseVersion { get; set; }
-
-        public static ReleaseDir fromPath(string path)
-        {
             string fileName = System.IO.Path.GetFileName(path);
             Tuple<string, string> parts = fileName.splitAt(RELEASE);
             if (parts == null || parts.Item2 == "")
@@ -26,9 +26,8 @@ namespace SimpleScriptRunnerBto
             };
         }
 
-        public override string ToString()
-        {
+    public override string ToString()
+    {
             return $"{nameof(Path)}: {Path}, {nameof(ReleaseVersion)}: {ReleaseVersion}";
         }
-    }
 }

--- a/SimpleScriptRunnerBto/ScriptVersion.cs
+++ b/SimpleScriptRunnerBto/ScriptVersion.cs
@@ -1,12 +1,12 @@
 using System;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+[Serializable]
+public class ScriptVersion : IComparable<ScriptVersion>
 {
-    [Serializable]
-    public class ScriptVersion : IComparable<ScriptVersion>
+    public ScriptVersion(int major, int minor, long patch, DateTime date, string machineName, string description)
     {
-        public ScriptVersion(int major, int minor, long patch, DateTime date, string machineName, string description)
-        {
             Major = major;
             Minor = minor;
             Patch = patch;
@@ -15,17 +15,17 @@ namespace SimpleScriptRunnerBto
             Description = description;
         }
 
-        public int Major { get; private set; }
-        public int Minor { get; private set; }
-        public long Patch { get; private set; }
-        public DateTime Date { get; set; }
-        public String MachineName { get; private set; }
-        public String Description { get; private set; }
+    public int Major { get; private set; }
+    public int Minor { get; private set; }
+    public long Patch { get; private set; }
+    public DateTime Date { get; set; }
+    public String MachineName { get; private set; }
+    public String Description { get; private set; }
 
-        public bool IsPatchNumeric { get { return Patch < 1000; } }        // Anything greater than 1000 is assumed to be a timestamp
+    public bool IsPatchNumeric { get { return Patch < 1000; } }        // Anything greater than 1000 is assumed to be a timestamp
 
-        public int CompareTo(ScriptVersion other)
-        {
+    public int CompareTo(ScriptVersion other)
+    {
             int compare = Major.CompareTo(other.Major);
             if (compare != 0)
                 return compare;
@@ -41,8 +41,8 @@ namespace SimpleScriptRunnerBto
             return RoundDateTime(Date).CompareTo(RoundDateTime(other.Date));
         }
 
-        public int compareIgnoreDate(ScriptVersion other)
-        {
+    public int compareIgnoreDate(ScriptVersion other)
+    {
             int compare = Major.CompareTo(other.Major);
             if (compare != 0)
                 return compare;
@@ -54,21 +54,21 @@ namespace SimpleScriptRunnerBto
             return Patch.CompareTo(other.Patch);
         }
 
-        protected bool Equals(ScriptVersion other)
-        {
+    protected bool Equals(ScriptVersion other)
+    {
             return Major == other.Major && Minor == other.Minor && Patch == other.Patch;
         }
 
-        public override bool Equals(object obj)
-        {
+    public override bool Equals(object obj)
+    {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
             if (obj.GetType() != GetType()) return false;
             return Equals((ScriptVersion) obj);
         }
 
-        public override int GetHashCode()
-        {
+    public override int GetHashCode()
+    {
             unchecked
             {
                 var hashCode = Major;
@@ -78,14 +78,13 @@ namespace SimpleScriptRunnerBto
             }
         }
 
-        public override string ToString()
-        {
+    public override string ToString()
+    {
             return String.Format("{0}.{1}, {2}, {3}", Major, Minor, Patch, Date);
         }
 
-        private DateTime RoundDateTime(DateTime dateTime)
-        {
+    private DateTime RoundDateTime(DateTime dateTime)
+    {
             return new DateTime(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second);
         }
-    }
 }

--- a/SimpleScriptRunnerBto/SimpleScriptRunnerBto.csproj
+++ b/SimpleScriptRunnerBto/SimpleScriptRunnerBto.csproj
@@ -10,7 +10,7 @@
         <PackageLicenseUrl>https://github.com/ericraider33/SimpleScriptRunner/blob/master/LICENSE.md</PackageLicenseUrl>
         <PackageTags>MySQL Database Migrations Scripts Version DevOps CommandLine</PackageTags>
         <PackageReleaseNotes>Modified directory scan to sort results to be consistent between win/Linux</PackageReleaseNotes>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SimpleScriptRunnerBto/TopProgram.cs
+++ b/SimpleScriptRunnerBto/TopProgram.cs
@@ -6,12 +6,12 @@ using System.Linq;
 using System.Reflection;
 using SimpleScriptRunnerBto.Util;
 
-namespace SimpleScriptRunnerBto
+namespace SimpleScriptRunnerBto;
+
+public class TopProgram
 {
-    public class TopProgram
+    public static int main(NameValueCollection appSettings, string[] argArray_)
     {
-        public static int main(NameValueCollection appSettings, string[] argArray_)
-        {
             Options options = Options.build(argArray_);
             if (options.SqlFile)
                 return sqlFileMain(appSettings, options.Params.ToArray());
@@ -48,8 +48,8 @@ namespace SimpleScriptRunnerBto
             return result;
         }
 
-        public static int sqlFileMain(NameValueCollection appSettings, string[] argArray)
-        {
+    public static int sqlFileMain(NameValueCollection appSettings, string[] argArray)
+    {
             Dictionary<String, String> switches = ArgsUtil.parseDictionary(ref argArray);
             if (argArray.Length == 0)
             {
@@ -91,8 +91,8 @@ namespace SimpleScriptRunnerBto
             return result;
         }
 
-        public static int simpleScriptRunnerProgramMain(Options options)
-        {
+    public static int simpleScriptRunnerProgramMain(Options options)
+    {
             try
             {
                 Program.executeRelease(options);
@@ -105,9 +105,8 @@ namespace SimpleScriptRunnerBto
             }
         }
 
-        private static void writeMessage(string origin, string subcategory, Program.Category category, string code, string text)
-        {
+    private static void writeMessage(string origin, string subcategory, Program.Category category, string code, string text)
+    {
             Console.WriteLine("{0} : {1} {2} {3} : {4}", origin, subcategory, category, code, text);
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Updater.cs
+++ b/SimpleScriptRunnerBto/Updater.cs
@@ -2,27 +2,27 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Design;
 
-namespace SimpleScriptRunnerBto
-{
-    public class Updater 
-    {
-        private readonly IScriptSource<ITextScriptTarget> scriptSource;
-        private readonly ITextScriptTarget scriptTarget;
-        private readonly Options options;
+namespace SimpleScriptRunnerBto;
 
-        private readonly List<int> skippedMajor = new List<int>();
-        private readonly List<int> skippedMinor = new List<int>();
-        private List<ScriptVersion> existingPatches;
+public class Updater 
+{
+    private readonly IScriptSource<ITextScriptTarget> scriptSource;
+    private readonly ITextScriptTarget scriptTarget;
+    private readonly Options options;
+
+    private readonly List<int> skippedMajor = new List<int>();
+    private readonly List<int> skippedMinor = new List<int>();
+    private List<ScriptVersion> existingPatches;
         
-        public Updater(IScriptSource<ITextScriptTarget> scriptSource, ITextScriptTarget scriptTarget, Options options)
-        {
+    public Updater(IScriptSource<ITextScriptTarget> scriptSource, ITextScriptTarget scriptTarget, Options options)
+    {
             this.scriptSource = scriptSource;
             this.scriptTarget = scriptTarget;
             this.options = options;
         }
         
-        public void applyScripts(ScriptVersion currentVersion)
-        {
+    public void applyScripts(ScriptVersion currentVersion)
+    {
             foreach (IScript<ITextScriptTarget> script in scriptSource.Scripts)
             {
                 if (script.Version.Major < currentVersion.Major)
@@ -63,5 +63,4 @@ namespace SimpleScriptRunnerBto
                 }
             }
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Util/ArgsUtil.cs
+++ b/SimpleScriptRunnerBto/Util/ArgsUtil.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SimpleScriptRunnerBto.Util
+namespace SimpleScriptRunnerBto.Util;
+
+public static class ArgsUtil
 {
-    public static class ArgsUtil
+    public static DateTime? parseDate(this String[] args, params String[] keys)
     {
-        public static DateTime? parseDate(this String[] args, params String[] keys)
-        {
             String match = args.FirstOrDefault(x => TextHelper.startsWithAny(x, keys));
             if (match == null || !match.Contains("="))
                 return null;
@@ -16,20 +16,20 @@ namespace SimpleScriptRunnerBto.Util
             return Convert.ToDateTime(value);
         }
 
-        public static String[] parseSwitches(ref String[] args)
-        {
+    public static String[] parseSwitches(ref String[] args)
+    {
             String[] switches = args.Where(x => x.StartsWith("-")).ToArray();
             args = args.Where(x => !x.StartsWith("-")).ToArray();
             return switches;
         }
 
-        public static Dictionary<String, String> parseDictionary(ref String[] args)
-        {
+    public static Dictionary<String, String> parseDictionary(ref String[] args)
+    {
             return asDictionary(parseSwitches(ref args));
         }
 
-        public static Dictionary<String, String> asDictionary(String[] args, StringComparer comparer = null)
-        {
+    public static Dictionary<String, String> asDictionary(String[] args, StringComparer comparer = null)
+    {
             comparer = comparer ?? StringComparer.OrdinalIgnoreCase;
             Dictionary<String, String> result = new Dictionary<String, String>(comparer);
             foreach (String theKey in args)
@@ -52,8 +52,8 @@ namespace SimpleScriptRunnerBto.Util
             return result;
         }
 
-        public static String value(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static String value(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             foreach (String key in keys)
             {
                 if (switchDictionary.ContainsKey(key))
@@ -62,23 +62,23 @@ namespace SimpleScriptRunnerBto.Util
             return null;
         }
 
-        public static int? valueInt(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static int? valueInt(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             return TextHelper.parseIntNullable(value(switchDictionary, keys));
         }
 
-        public static long? valueLong(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static long? valueLong(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             return TextHelper.parseLongNullable(value(switchDictionary, keys));
         }
 
-        public static double? valueDouble(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static double? valueDouble(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             return TextHelper.parseDoubleNullable(value(switchDictionary, keys));
         }
 
-        public static bool? valueBool(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static bool? valueBool(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             foreach (String key in keys)
             {
                 if (!switchDictionary.ContainsKey(key))
@@ -94,9 +94,8 @@ namespace SimpleScriptRunnerBto.Util
             return null;
         }
 
-        public static bool hasAny(this Dictionary<String, String> switchDictionary, params String[] keys)
-        {
+    public static bool hasAny(this Dictionary<String, String> switchDictionary, params String[] keys)
+    {
             return keys.Any(switchDictionary.ContainsKey);
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Util/MapHelper.cs
+++ b/SimpleScriptRunnerBto/Util/MapHelper.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace SimpleScriptRunnerBto.Util
+namespace SimpleScriptRunnerBto.Util;
+
+public static class MapHelper
 {
-    public static class MapHelper
+    public static VType cache<KType, VType>(this Dictionary<KType, VType> map, KType key, Func<VType> builder)
     {
-        public static VType cache<KType, VType>(this Dictionary<KType, VType> map, KType key, Func<VType> builder)
-        {
             if (map.ContainsKey(key))
                 return map[key];
 
@@ -17,8 +17,8 @@ namespace SimpleScriptRunnerBto.Util
             return value;
         }
 
-        public static String toValueString<KType, VType>(this Dictionary<KType, VType> map) where KType : IComparable
-        {
+    public static String toValueString<KType, VType>(this Dictionary<KType, VType> map) where KType : IComparable
+    {
             StringBuilder result = new StringBuilder();
 
             foreach (KType key in map.Keys.OrderBy(x => x))
@@ -31,23 +31,23 @@ namespace SimpleScriptRunnerBto.Util
             return result.ToString();
         }
 
-        public static VType getValue<KType, VType>(this Dictionary<KType, VType> map, KType key) where KType : IComparable
-        {
+    public static VType getValue<KType, VType>(this Dictionary<KType, VType> map, KType key) where KType : IComparable
+    {
             if (map.ContainsKey(key))
                 return map[key];
             return default(VType);
         }
 
-        public static void setValue<KType, VType>(this Dictionary<KType, VType> map, KType key, VType value) where KType : IComparable
-        {
+    public static void setValue<KType, VType>(this Dictionary<KType, VType> map, KType key, VType value) where KType : IComparable
+    {
             if (map.ContainsKey(key))
                 map[key] = value;
             else
                 map.Add(key, value);
         }
 
-        public static List<KType> findMissingKeys<KType, VType>(this Dictionary<KType, VType> map, IEnumerable<KType> keys)
-        {
+    public static List<KType> findMissingKeys<KType, VType>(this Dictionary<KType, VType> map, IEnumerable<KType> keys)
+    {
             List<KType> results = new List<KType>();
             foreach (KType key in keys)
                 if (!map.ContainsKey(key))
@@ -56,8 +56,8 @@ namespace SimpleScriptRunnerBto.Util
             return results;
         }
 
-        public static List<KType> findExtraneousKeys<KType, VType>(this Dictionary<KType, VType> map, ICollection<KType> keys)
-        {
+    public static List<KType> findExtraneousKeys<KType, VType>(this Dictionary<KType, VType> map, ICollection<KType> keys)
+    {
             List<KType> results = new List<KType>();
             foreach (KType key in map.Keys)
                 if (!keys.Contains(key))
@@ -65,5 +65,4 @@ namespace SimpleScriptRunnerBto.Util
 
             return results;
         }
-    }
 }

--- a/SimpleScriptRunnerBto/Util/TextHelper.cs
+++ b/SimpleScriptRunnerBto/Util/TextHelper.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace SimpleScriptRunnerBto.Util
+namespace SimpleScriptRunnerBto.Util;
+
+public static class TextHelper
 {
-    public static class TextHelper
+    public static Tuple<String, String> splitAt(this String input, String token)
     {
-        public static Tuple<String, String> splitAt(this String input, String token)
-        {
             if (string.IsNullOrEmpty(input))
                 return null;
 
@@ -18,24 +18,24 @@ namespace SimpleScriptRunnerBto.Util
             return new Tuple<string, string>(input.Substring(0, index), input.Substring(index + token.Length));
         }
 
-        public static bool startsWithIgnoreCase(this String value, String toFind)
-        {
+    public static bool startsWithIgnoreCase(this String value, String toFind)
+    {
             if (value == null || toFind == null)
                 return false;
 
             return value.IndexOf(toFind, StringComparison.CurrentCultureIgnoreCase) == 0;
         }
 
-        public static bool startsWithAny(String text, IEnumerable<String> toFind, bool ignoreCase = true)
-        {
+    public static bool startsWithAny(String text, IEnumerable<String> toFind, bool ignoreCase = true)
+    {
             if (ignoreCase)
                 return toFind.Any(x => startsWithIgnoreCase(text, x));
 
             return toFind.Any(text.StartsWith);
         }
 
-        public static int? parseIntNullable(String source)
-        {
+    public static int? parseIntNullable(String source)
+    {
             if (String.IsNullOrEmpty(source))
                 return null;
 
@@ -49,8 +49,8 @@ namespace SimpleScriptRunnerBto.Util
             }
         }
 
-        public static long? parseLongNullable(String source)
-        {
+    public static long? parseLongNullable(String source)
+    {
             if (String.IsNullOrEmpty(source))
                 return null;
 
@@ -64,8 +64,8 @@ namespace SimpleScriptRunnerBto.Util
             }
         }
 
-        public static double? parseDoubleNullable(String source)
-        {
+    public static double? parseDoubleNullable(String source)
+    {
             if (String.IsNullOrEmpty(source))
                 return null;
 
@@ -79,8 +79,8 @@ namespace SimpleScriptRunnerBto.Util
             }
         }
 
-        public static bool isEqualsIgnoreCase(String a, String b)
-        {
+    public static bool isEqualsIgnoreCase(String a, String b)
+    {
             if (a == null)
                 return b == null;
 
@@ -90,11 +90,10 @@ namespace SimpleScriptRunnerBto.Util
             return a.Equals(b, StringComparison.CurrentCultureIgnoreCase);
         }
 
-        public static bool parseBool(String value, bool defaultValue = false)
-        {
+    public static bool parseBool(String value, bool defaultValue = false)
+    {
             if (isEqualsIgnoreCase(value, "true")) return true;
             if (isEqualsIgnoreCase(value, "false")) return false;
             return defaultValue;
         }        
-    }
 }


### PR DESCRIPTION
1. The `SimpleScriptRunnerBto` library has been re-targeted from .NET Standard to .NET 6, 7, and 8, since those are the currently supported .NET versions
2. All source code has been updated to use file-scoped namespaces
3. The Program.cs files for the console applications have been updated to use top-level code